### PR TITLE
refactor: Remove mandatory MPIC from the validation process

### DIFF
--- a/draft-sheurich-acme-dns-persist.md
+++ b/draft-sheurich-acme-dns-persist.md
@@ -276,7 +276,7 @@ For CAs subject to requirements like the CA/Browser Forum Baseline Requirements,
 
 ## Validation Data Reuse and TTL Handling {#validation-data-reuse-and-ttl-handling}
 
-This validation method is explicitly designed for persistence and reuse. The period for which a CA may rely on validation data is its `Validation Data Reuse Period` (as defined in {{conventions-and-definitions}}). However, if the DNS TXT record's Time-to-Live (TTL) is shorter than this period, the CA MUST adjust the effective validation data reuse period for that specific validation. In such cases, the effective validation data reuse period SHALL be the greater of: (a) the DNS TXT record's TTL, or (b) 8 hours.
+This validation method is explicitly designed for persistence and reuse. The period for which a CA may rely on validation data is its `Validation Data Reuse Period` (as defined in {{conventions-and-definitions}}). However, if the DNS TXT record's Time-to-Live (TTL) is shorter than this period, the CA MUST treat the record's TTL as the effective validation data reuse period for that specific validation.
 
 CAs MAY reuse validation data obtained through this method for the duration of their validation data reuse period, subject to the TTL constraints described in this section. The `persistUntil` parameter indicates when the DNS validation record should no longer be considered valid for new validation attempts. If a `persistUntil` parameter is present in the DNS TXT record, the CA MUST NOT successfully complete a validation attempt after the date and time specified in that parameter. This restriction does not preclude reuse of data that has already been validated.
 


### PR DESCRIPTION
Removes mandatory multi-perspective validation in favor of DNS query-based validation. MPIC becomes optional guidance in a new DNS security measures section alongside DNSSEC recommendations.

Also reorganizes "Validation Data Reuse and TTL Handling" to clarify how the reuse period and `persistUntil` interact, and removes MPIC references that were duplicated across sections.

Fixes #12
Fixes #17
Fixes #20
