### PR TITLE
feat: add accounturi attribute to the challenge object

### DIFF
--- a/draft-ietf-acme-dns-persist.md
+++ b/draft-ietf-acme-dns-persist.md
@@ -3,7 +3,7 @@ title: "Automated Certificate Management Environment (ACME) Challenge for Persis
 abbrev: "ACME Persistent DNS Challenge"
 category: std
 submissionType: IETF
-docname: draft-sheurich-acme-dns-persist-latest
+docname: draft-ietf-acme-dns-persist-latest
 ipr: trust200902
 area: "Security"
 workgroup: "Automated Certificate Management Environment"
@@ -27,8 +27,8 @@ author:
    email: "sheurich@fastly.com"
  -
    name: "Henry Birge-Lee"
-   org: "Princeton University"
-   email: "birgelee@princeton.edu"
+   org: "Crosslayer Labs, Inc."
+   email: "henry@crosslayerlabs.com"
  -
    name: "Michael Slaughter"
    org: "Amazon Trust Services"


### PR DESCRIPTION
Added accounturi attribute to the challenge response object.

Changes include:
- Updated accounturi references to refer to the server provided accounturi rather than "a valid account uri"
- Cleaned up accounturi references and examples.


**Motivation**: This change eliminates ambiguity and improves interoperability of implementations. While ACME clients are aware of their account URI, explicitly providing this value in the challenge object removes any dependency on client-side URI construction or format assumptions. This approach makes the exact value the server expects in DNS explicit and ensures the challenge object is completely self-contained and driven by the server.