### PR TITLE
Clarify case-handling rules for parameter values

### DIFF
--- a/draft-ietf-acme-dns-persist.md
+++ b/draft-ietf-acme-dns-persist.md
@@ -178,7 +178,7 @@ The RDATA of this TXT record MUST fulfill the following requirements:
 
 This specification defines the following case-handling rules for parameter values in dns-persist-01 records:
 
-- `accounturi`: The value is a URI. Implementations MUST compare `accounturi` values using Simple String Comparison per {{!RFC3986}}, Section 6.2.1, with no case-folding or other normalization.
+- `accounturi`: The value is a URI. CAs MUST compare `accounturi` values using Simple String Comparison per {{!RFC3986}}, Section 6.2.1, with no case-folding or other normalization.
 - `policy`: Case-insensitive, as specified in item 4 above.
 - `persistUntil`: The value is a base-10 integer. Case does not apply.
 


### PR DESCRIPTION
Addresses #34.

## Problem

The draft requires case-insensitive comparison for `policy` values but says nothing about the case-handling of `accounturi` or `persistUntil` values. An implementer (@beautifulentropy, working on [Pebble support](https://github.com/letsencrypt/pebble/pull/536)) asked: what makes `policy` special?

The asymmetry is correct, but the draft doesn't explain it:
- `accounturi` values are URIs — case-sensitive per RFC 3986
- `persistUntil` values are integers — case is inapplicable
- `policy` values are protocol keywords — case-insensitivity is a deliberate usability choice

RFC 8659 §4.1 makes parameter *tags* case-insensitive but defines no rules for parameter *values*, leaving that to whichever specification defines the parameter.

## Changes

**Item 4 (policy parameter):** Replace the ambiguous sentence *"The parameter's 'tag' and its defined values MUST be treated as case-insensitive"* with a statement scoped to `policy` values only. The tag clause was redundant (already covered by RFC 8659 §4.1).

**New paragraph after item 5:** State the case-handling rules for all parameter values in one place:
- `accounturi`: Simple String Comparison per RFC 3986 §6.2.1; MUST NOT case-fold
- `policy`: case-insensitive (protocol keywords, often manually provisioned)
- `persistUntil`: base-10 integer; case does not apply

## Compatibility with #35

PR #35 adds `accounturi` comparison semantics to item 3 (simple string comparison, no normalization/case-folding). The new paragraph here reinforces that without conflicting. Both PRs can merge in either order.