### PR TITLE
Change language since issuer-domain-name is a opaque value

### DIFF
--- a/draft-ietf-acme-dns-persist.md
+++ b/draft-ietf-acme-dns-persist.md
@@ -389,7 +389,7 @@ The persistent nature of validation records raises concerns about potential reus
 
 DNS records are generally not authenticated end-to-end, making them potentially vulnerable to tampering. CAs SHOULD implement additional integrity checks where possible and consider the overall security posture of the DNS infrastructure when relying on persistent validation records.
 
-Additionally, CAs SHOULD protect their `issuer-domain-name` with appropriate security measures. Using DNSSEC to protect the CA's `issuer-domain-name` is RECOMMENDED. An attacker who compromises the DNS for a CA's `issuer-domain-name` could disrupt validation or potentially impersonate the CA in certain scenarios. While this is a systemic DNS security risk that extends beyond this specification, it is amplified by any mechanism that relies on DNS for identity.
+Additionally, CAs SHOULD protect their `ACME directory URL` with appropriate security measures. Using DNSSEC to protect the CA's `ACME directory URL` is RECOMMENDED. An attacker who compromises the DNS for a CA's `ACME directory URL` could disrupt validation or potentially impersonate the CA in certain scenarios. While this is a systemic DNS security risk that extends beyond this specification, it is amplified by any mechanism that relies on DNS for identity.
 
 ## Issuer Domain Name Normalization and Limits
 


### PR DESCRIPTION
Closes https://github.com/ietf-wg-acme/draft-ietf-acme-dns-persist/issues/63 if merged

This because issuer-domain-name is just a opaque value, and "protecting" that value with DNSSEC - especially if its a legacy domain name that the CA does not own anymore, will not give any security advantage.

It would be analogous to protecting a sign outside a bank with heavy security but have glass doors to the vault.

The sensitive resource for a CA - that needs protecting - is the ACME Directory URL - also called Server URL. Thats the sensitive ACME resource the CA owns and is the root of trust for the ACME client.